### PR TITLE
Add makefile to build and push image to Dockerhub

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,9 @@
+IMAGE := ministryofjustice/cloud-platform-helloworld-ruby
+TAG := 1.0
+
+build:
+	docker build -t $(IMAGE) .
+
+push:
+	docker tag $(IMAGE) $(IMAGE):$(TAG)
+	docker push $(IMAGE):$(TAG)


### PR DESCRIPTION
As the Cloud Platform team are using this image for than its intended purpose, it makes sense the image lives in the ministryofjustice Dockerhub.