### PR TITLE
Modify yaml code for dedicated ingress-controller

### DIFF
--- a/kubectl_deploy/certificate.yaml
+++ b/kubectl_deploy/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: helloworld-dstest.live-1.cloud-platform.service.justice.gov.uk
+  namespace: dstest
+spec:
+  secretName: dstest-ssl-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - helloworld-dstest.live-1.cloud-platform.service.justice.gov.uk

--- a/kubectl_deploy/ingress.yaml
+++ b/kubectl_deploy/ingress.yaml
@@ -2,12 +2,15 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: helloworld-rubyapp-ingress
+  annotations:
+    kubernetes.io/ingress.class: dstest
 spec:
   tls:
   - hosts:
-    - helloworld-rubyapp.apps.live-1.cloud-platform.service.justice.gov.uk
+    - helloworld-dstest.live-1.cloud-platform.service.justice.gov.uk
+    secretName: dstest-ssl-cert
   rules:
-  - host: helloworld-rubyapp.apps.live-1.cloud-platform.service.justice.gov.uk
+  - host: helloworld-dstest.live-1.cloud-platform.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
This change demonstrates a "hello world" deployment that uses a
dedicated ingress controller. This is going to be the default from now
on, so the user guide tutorial will also need to be modified so that a
dedicated ingress controller is created with the tutorial namespace.

This change should not be deployed until we have modified the cloud
platform CLI so that an ingress controller is created by default, with
every new namespace.

related to
https://github.com/ministryofjustice/cloud-platform/issues/2224
