### PR TITLE
Add ingress class annotation

### DIFF
--- a/kubectl_deploy/ingress.yaml
+++ b/kubectl_deploy/ingress.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: helloworld-rubyapp-ingress
+  annotations:
+    kubernetes.io/ingress.class: mynamespace
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
I'm updating the Hello World tutorial in the user guide, to reflect the current state of the cluster and how we use ingresses etc.

All ingresses should now have an ingress class matching the user's namespace name.