### PR TITLE
Remove ingress class annotation

### DIFF
--- a/kubectl_deploy/ingress.yaml
+++ b/kubectl_deploy/ingress.yaml
@@ -2,8 +2,6 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: helloworld-rubyapp-ingress
-  annotations:
-    kubernetes.io/ingress.class: mynamespace
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
Users will not have a dedicated ingress for their namespace, when they deploy the helloworld application.