### PR TITLE
Fix helloworld ingress post v1 api changes

### DIFF
--- a/kubectl_deploy/ingress.yaml
+++ b/kubectl_deploy/ingress.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: helloworld
   annotations:
     kubernetes.io/ingress.class: nginx
-    external-dns.alpha.kubernetes.io/set-identifier: heloworld-<mynamespace>-green
+    external-dns.alpha.kubernetes.io/set-identifier: helloworld-<mynamespace>-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:


### PR DESCRIPTION
Following hello world CP user guide, kubectl apply failed due to ingress.yaml errors: missing kind field, and ingress name typo for set-identifier.